### PR TITLE
Update Elecho references to current AI Medewerker positioning

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 5173
+    },
+    {
+      "name": "preview",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "preview"],
+      "port": 4173
+    }
+  ]
+}

--- a/src/projects.ts
+++ b/src/projects.ts
@@ -39,7 +39,7 @@ const projects: ProjectType[] = [
   {
     name: 'Elecho Website',
     role: 'Web Developer',
-    description: 'For my company Elecho I have created the website in NextJS. The website is created with a custom design and is fully responsive. Furthermore it is optimized for SEO, i18n and has a blog.',
+    description: 'For my company Elecho I built the website in NextJS with a custom, fully responsive design and optimized it for SEO.',
     images: [elechoImg],
     link: 'https://elecho.io',
     slug: 'elecho',

--- a/src/sections/about/About.tsx
+++ b/src/sections/about/About.tsx
@@ -82,9 +82,9 @@ const About = () => {
             Ambitions
           </h4>
           <p className={'about-who__text'}>
-            My ambition with Elecho is to help founders turn ideas into validated MVPs and scalable products.
-            I focus on AI and automation to remove bottlenecks, speed up execution and build practical software
-            with real business impact.
+            My ambition with Elecho is to help Dutch SMBs put AI to work by building reliable AI employees
+            that take over repetitive processes. I focus on AI and automation to remove bottlenecks and
+            deliver software with real business impact.
           </p>
         </div>
         <div id={'whoiam-part'} className={'about-description'}>

--- a/src/sections/front/Front.tsx
+++ b/src/sections/front/Front.tsx
@@ -35,8 +35,8 @@ const Front = () => {
                                                                                 target={'_blank'}
                                                                                 href={'https://deltafontysict.nl/'}>delta</a> programme
             at FHICT. I co-run <a className={'front-link'} target="_blank"
-                                  href={'https://www.elecho.io'}>Elecho</a> focused on creating and expanding MVP&apos;s
-            and also currently work at <a className={'front-link'} target="_blank"
+                                  href={'https://www.elecho.io'}>Elecho</a>, where we build AI employees that automate repetitive
+            work for Dutch SMBs, and also currently work at <a className={'front-link'} target="_blank"
                                           href={'https://www.proforto.nl/'}>Proforto</a> as an automations engineer.
           </p>
         </div>

--- a/src/sections/resume/Resume.tsx
+++ b/src/sections/resume/Resume.tsx
@@ -28,11 +28,11 @@ const Resume = () => {
     },
     {
       id: 'elecho',
-      title: 'Fullstack Engineer',
+      title: 'Co-founder & Full-stack Developer',
       organization: 'Elecho',
       period: '2024 - now',
       type: 'work',
-      details: 'Building web products with a focus on maintainable architecture, UX quality and performance.'
+      details: 'Building AI employees that run 24/7 and automate repetitive processes for Dutch SMBs.'
     },
     {
       id: 'webyx',


### PR DESCRIPTION
## Summary
- The portfolio described Elecho as an MVP/web studio. Elecho now delivers AI employees ("AI Medewerkers") that automate repetitive processes for Dutch SMBs. Verified against the live elecho.io and Elecho's company knowledge base.
- Updated four spots so the positioning matches:
  - **About → Ambitions**: dropped the "help founders turn ideas into MVPs" framing in favor of building reliable AI employees for Dutch SMBs.
  - **Front intro**: "I co-run Elecho, where we build AI employees that automate repetitive work for Dutch SMBs".
  - **Resume → Elecho**: title changed `Fullstack Engineer` → `Co-founder & Full-stack Developer`; details updated to reflect the AI Medewerker work.
  - **Projects → Elecho Website**: removed the outdated i18n/blog claims (no active blog; EN/NL run on separate domains), kept the accurate NextJS + SEO description.
- Added `.claude/launch.json` with the Vite `dev` (:5173) and `preview` (:4173) server configs.

## Why
Jasper flagged the portfolio's Elecho content as out of date. Cross-checked against elecho.io and the Elecho knowledge base; the MVP/web-studio framing no longer reflects the company.

## Reviewer notes
- Content-only string edits in valid JSX/TS — no structural/type changes.
- The unrelated `package-lock.json` churn from a local `npm install` (npm v11 stripping `"peer": true`) was intentionally reverted to keep this PR focused. `node_modules` and `.claude/settings.local.json` are not included.
- Verified the Vite dev server compiles cleanly with these changes (only pre-existing Dart Sass `@import` deprecation warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)